### PR TITLE
fix-print-page-breaks-pdf-export

### DIFF
--- a/packages/pdf-export/README.md
+++ b/packages/pdf-export/README.md
@@ -417,6 +417,26 @@ Import in your global CSS:
 @import 'fumadocs-pdf-export/styles/print.css';
 ```
 
+## Fixing Page Break Issues
+
+The built-in print styles handle headings, images, code blocks, blockquotes, and Fumadocs callouts. If you have custom components that break across pages, add `break-inside: avoid` in your own CSS:
+
+```css
+@media print {
+  /* Prevent your custom component from splitting across pages */
+  .my-component {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+}
+```
+
+Common causes of unwanted page breaks:
+
+- **Custom card/callout components** — any container with a visible border or background will look broken when split across pages. Fix with `break-inside: avoid`.
+- **Step/timeline components** — project-specific step containers (e.g. `.fes-step`) need `break-inside: avoid` added in your local CSS.
+- **Tall elements** — `break-inside: avoid` on a very tall element will push it to the next page entirely, potentially leaving a large gap. If the element can be taller than a page, don't use `break-inside: avoid` on it — let it split naturally.
+
 ## Troubleshooting
 
 ### Puppeteer fails to launch

--- a/packages/pdf-export/package.json
+++ b/packages/pdf-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fumadocs-pdf-export",
-  "version": "1.2.1-exp.4",
+  "version": "1.2.1-exp.6",
   "description": "PDF export plugin for Fumadocs documentation sites",
   "homepage": "https://github.com/sebastianhuus/fumadocs-pdf-export",
   "license": "MIT",

--- a/packages/pdf-export/package.json
+++ b/packages/pdf-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fumadocs-pdf-export",
-  "version": "1.2.1-exp.2",
+  "version": "1.2.1-exp.4",
   "description": "PDF export plugin for Fumadocs documentation sites",
   "homepage": "https://github.com/sebastianhuus/fumadocs-pdf-export",
   "license": "MIT",

--- a/packages/pdf-export/package.json
+++ b/packages/pdf-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fumadocs-pdf-export",
-  "version": "1.2.1-exp.1",
+  "version": "1.2.1-exp.2",
   "description": "PDF export plugin for Fumadocs documentation sites",
   "homepage": "https://github.com/sebastianhuus/fumadocs-pdf-export",
   "license": "MIT",

--- a/packages/pdf-export/package.json
+++ b/packages/pdf-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fumadocs-pdf-export",
-  "version": "1.2.1-exp.6",
+  "version": "1.3.0",
   "description": "PDF export plugin for Fumadocs documentation sites",
   "homepage": "https://github.com/sebastianhuus/fumadocs-pdf-export",
   "license": "MIT",

--- a/packages/pdf-export/package.json
+++ b/packages/pdf-export/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fumadocs-pdf-export",
-  "version": "1.2.0",
+  "version": "1.2.1-exp.1",
   "description": "PDF export plugin for Fumadocs documentation sites",
   "homepage": "https://github.com/sebastianhuus/fumadocs-pdf-export",
   "license": "MIT",

--- a/packages/pdf-export/src/core.ts
+++ b/packages/pdf-export/src/core.ts
@@ -403,7 +403,6 @@ async function cleanupPageForPdf(page: PuppeteerPage, config: ResolvedConfig) {
       // Disable all page-break rules — the PDF is a single continuous page
       const noBreaks = document.createElement('style');
       noBreaks.textContent = `
-        @page { margin: 0 !important; }
         * {
           break-before: auto !important;
           break-after: auto !important;

--- a/packages/pdf-export/src/core.ts
+++ b/packages/pdf-export/src/core.ts
@@ -266,7 +266,7 @@ async function triggerLazyImages(page: PuppeteerPage) {
  */
 async function cleanupPageForPdf(page: PuppeteerPage, config: ResolvedConfig) {
   await page.evaluate(
-    (contentSelector, removeSelectors, accordionContentSelectors, pageWidth) => {
+    (contentSelector, removeSelectors, accordionContentSelectors) => {
       const content = document.querySelector(contentSelector);
       if (!content) return;
 
@@ -403,7 +403,6 @@ async function cleanupPageForPdf(page: PuppeteerPage, config: ResolvedConfig) {
       // Disable all page-break rules — the PDF is a single continuous page
       const noBreaks = document.createElement('style');
       noBreaks.textContent = `
-        @page { size: ${pageWidth}px 99999px !important; }
         * {
           break-before: auto !important;
           break-after: auto !important;
@@ -413,6 +412,27 @@ async function cleanupPageForPdf(page: PuppeteerPage, config: ResolvedConfig) {
           page-break-inside: auto !important;
         }
       `;
+
+      // Remove any @page rules from existing stylesheets so page.pdf() controls dimensions
+      for (const sheet of Array.from(document.styleSheets)) {
+        try {
+          const rules = sheet.cssRules;
+          for (let i = rules.length - 1; i >= 0; i--) {
+            const rule = rules[i];
+            if (rule instanceof CSSPageRule) {
+              sheet.deleteRule(i);
+            } else if (rule instanceof CSSMediaRule && rule.conditionText === 'print') {
+              for (let j = rule.cssRules.length - 1; j >= 0; j--) {
+                if (rule.cssRules[j] instanceof CSSPageRule) {
+                  rule.deleteRule(j);
+                }
+              }
+            }
+          }
+        } catch (_) {
+          // Cross-origin stylesheets may throw — skip them
+        }
+      }
       document.head.appendChild(noBreaks);
 
       contentClone.style.marginTop = '0';
@@ -426,8 +446,7 @@ async function cleanupPageForPdf(page: PuppeteerPage, config: ResolvedConfig) {
     },
     config.contentSelector,
     config.removeSelectors,
-    config.accordionContentSelectors,
-    config.pageWidth
+    config.accordionContentSelectors
   );
 
   // Scroll through the cleaned page to force the browser to paint all elements

--- a/packages/pdf-export/src/core.ts
+++ b/packages/pdf-export/src/core.ts
@@ -266,7 +266,7 @@ async function triggerLazyImages(page: PuppeteerPage) {
  */
 async function cleanupPageForPdf(page: PuppeteerPage, config: ResolvedConfig) {
   await page.evaluate(
-    (contentSelector, removeSelectors, accordionContentSelectors) => {
+    (contentSelector, removeSelectors, accordionContentSelectors, pageWidth) => {
       const content = document.querySelector(contentSelector);
       if (!content) return;
 
@@ -403,7 +403,7 @@ async function cleanupPageForPdf(page: PuppeteerPage, config: ResolvedConfig) {
       // Disable all page-break rules — the PDF is a single continuous page
       const noBreaks = document.createElement('style');
       noBreaks.textContent = `
-        @page { size: 99999px !important; }
+        @page { size: ${pageWidth}px 99999px !important; }
         * {
           break-before: auto !important;
           break-after: auto !important;
@@ -426,7 +426,8 @@ async function cleanupPageForPdf(page: PuppeteerPage, config: ResolvedConfig) {
     },
     config.contentSelector,
     config.removeSelectors,
-    config.accordionContentSelectors
+    config.accordionContentSelectors,
+    config.pageWidth
   );
 
   // Scroll through the cleaned page to force the browser to paint all elements

--- a/packages/pdf-export/src/core.ts
+++ b/packages/pdf-export/src/core.ts
@@ -403,6 +403,7 @@ async function cleanupPageForPdf(page: PuppeteerPage, config: ResolvedConfig) {
       // Disable all page-break rules — the PDF is a single continuous page
       const noBreaks = document.createElement('style');
       noBreaks.textContent = `
+        @page { size: 99999px !important; }
         * {
           break-before: auto !important;
           break-after: auto !important;

--- a/packages/pdf-export/src/core.ts
+++ b/packages/pdf-export/src/core.ts
@@ -400,6 +400,21 @@ async function cleanupPageForPdf(page: PuppeteerPage, config: ResolvedConfig) {
         htmlEl.style.height = 'auto';
       });
 
+      // Disable all page-break rules — the PDF is a single continuous page
+      const noBreaks = document.createElement('style');
+      noBreaks.textContent = `
+        @page { margin: 0 !important; }
+        * {
+          break-before: auto !important;
+          break-after: auto !important;
+          break-inside: auto !important;
+          page-break-before: auto !important;
+          page-break-after: auto !important;
+          page-break-inside: auto !important;
+        }
+      `;
+      document.head.appendChild(noBreaks);
+
       contentClone.style.marginTop = '0';
       contentClone.style.paddingTop = '0';
 

--- a/packages/pdf-export/src/styles/print.css
+++ b/packages/pdf-export/src/styles/print.css
@@ -26,6 +26,12 @@
     break-inside: avoid;
   }
 
+  /* Keep headings with their following content */
+  h1, h2, h3, h4, h5, h6 {
+    break-after: avoid;
+    page-break-after: avoid;
+  }
+
   /* Remove excessive margins in print */
   h1, h2, h3, h4, h5, h6 {
     margin-top: 1em !important;
@@ -71,6 +77,14 @@
   .nextra-toc,
   .nextra-breadcrumb {
     display: none !important;
+  }
+
+  /* ================================================
+   * Fumadocs callout containers
+   * ================================================ */
+  div:has(> div[role='none']) {
+    break-inside: avoid;
+    page-break-inside: avoid;
   }
 
   /* ================================================
@@ -147,6 +161,8 @@
 
   img {
     max-width: 100% !important;
+    max-height: 70vh !important;
+    object-fit: contain !important;
     page-break-inside: avoid !important;
   }
 

--- a/packages/pdf-export/src/styles/print.css
+++ b/packages/pdf-export/src/styles/print.css
@@ -54,6 +54,10 @@
     --fd-sidebar-width: 0px !important;
   }
 
+  #nd-page {
+    display: block !important;
+  }
+
   #nd-sidebar,
   #nd-toc,
   nav,

--- a/packages/pdf-export/src/styles/print.css
+++ b/packages/pdf-export/src/styles/print.css
@@ -21,9 +21,16 @@
   h1, h2, h3, h4, h5, h6,
   pre, code,
   img,
+  figure,
   blockquote {
     page-break-inside: avoid;
     break-inside: avoid;
+  }
+
+  /* Keep figures (code blocks, etc.) attached to their introductory content */
+  figure {
+    break-before: avoid;
+    page-break-before: avoid;
   }
 
   /* Keep headings with their following content */


### PR DESCRIPTION
fixes a bunch of default page break issues with default components in fumadocs